### PR TITLE
Improve README and documentation, clarify optional CEC/LIRC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ sudo apt-get install mosquitto
 Install python dev packages, lirc, cec & paho-mqtt modules
 ```sh
 sudo apt-get update
-sudo apt-get install build-essential git lirc python3 python3-dev python3-setuptools python3-pip python3-wheel python3-build python3-venv python3-paho-mqtt python3-cec
+sudo apt-get install build-essential git lirc liblirc-dev liblircclient-dev pkg-config python3 python3-dev python3-setuptools python3-pip python3-wheel python3-build python3-venv python3-paho-mqtt python3-cec
 sudo pip install /usr/share/lirc/lirc-*.tar.gz
 git clone https://github.com/ballle98/cec-mqtt-bridge.git
 cd cec-mqtt-bridge/contrib/

--- a/README.md
+++ b/README.md
@@ -46,11 +46,17 @@ If there is not a MQTT broker already on your network
 sudo apt-get install mosquitto
 ```
 
-Install python dev packages, lirc, cec & paho-mqtt modules
+Install packages and the bridge
 ```sh
+# Base packages
 sudo apt-get update
-sudo apt-get install build-essential git lirc liblirc-dev liblircclient-dev pkg-config python3 python3-dev python3-setuptools python3-pip python3-wheel python3-build python3-venv python3-paho-mqtt python3-cec
+sudo apt-get install build-essential git python3 python3-dev python3-setuptools python3-pip python3-wheel python3-build python3-venv python3-paho-mqtt python3-cec
+
+# Optional: LIRC support (includes build helper for source installs)
+sudo apt-get install lirc liblirc-dev liblircclient-dev pkg-config
 sudo pip install /usr/share/lirc/lirc-*.tar.gz
+
+# Install the bridge
 git clone https://github.com/ballle98/cec-mqtt-bridge.git
 cd cec-mqtt-bridge/contrib/
 ./debian-ubuntu-install.sh

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ sudo apt-get update
 sudo apt-get install build-essential git lirc python3 python3-dev python3-setuptools python3-pip python3-wheel python3-build python3-venv python3-paho-mqtt python3-cec
 sudo pip install /usr/share/lirc/lirc-*.tar.gz
 git clone https://github.com/ballle98/cec-mqtt-bridge.git
-cd cec-mqtt-bridge/
-./contrib/debian-ubuntu-install.sh
+cd cec-mqtt-bridge/contrib/
+./debian-ubuntu-install.sh
 sudo vi /etc/cec-mqtt-bridge.ini
 sudo systemctl restart cec-mqtt-bridge
 ```

--- a/config.ini.default
+++ b/config.ini.default
@@ -2,30 +2,30 @@
 ; MQTT broker configuration
 ;
 [mqtt]
-; Hostname of mqtt broker (required)
+; Hostname of mqtt broker (default=localhost)
 ;broker=localhost
 
 ; Port to connect to (default=1883)
 ;port=1883
 
-; Use TLS
+; Use TLS (default=0)
 ;tls=0
 
 ; Username and password
 ;user=
 ;password=
 
-; MQTT prefix to use
+; MQTT prefix to use (default=media)
 ;prefix=cec-mqtt
 
-; Name of your device (default=cec-ir-mqtt)
+; Name of your device (default=CEC Bridge)
 ;name=cec-ir-mqtt
 
 ;
 ; HDMI-CEC configuration
 ;
 [cec]
-; Enable CEC
+; Enable CEC (default=0)
 enabled=1
 
 ; ID of CEC controller
@@ -41,7 +41,7 @@ enabled=1
 ; Devices to query (comma seperated, defaults to all devices)
 ;devices=0,2,3,4,5
 
-; Name of your device (default=cec-ir-mqtt)
+; Name of your device (default=CEC Bridge)
 ;name=OSMC
 
 ; device power state refresh time in seconds (default=10) (min 10) (0 disables refresh)
@@ -51,7 +51,7 @@ enabled=1
 ; LIRC configuration
 ;
 [ir]
-; Enable LIRC
+; Enable LIRC (default=0)
 ;enabled=1
 rx_sock_path=/var/run/lirc/lircd
 tx_sock_path=/var/run/lirc/lircd-tx

--- a/src/cec_mqtt_bridge/hdmicec.py
+++ b/src/cec_mqtt_bridge/hdmicec.py
@@ -9,7 +9,10 @@ import threading
 import time
 import os
 from typing import List
-import cec
+try:
+    import cec
+except ModuleNotFoundError:
+    cec = None
 
 LOGGER = logging.getLogger(__name__)
 
@@ -25,6 +28,8 @@ DEFAULT_CONFIGURATION = {
 class HdmiCec:
     """HDMI CEC interface class"""
     def __init__(self, port: str, name: str, devices: List[int], mqtt_send: callable):
+        if cec is None:
+            raise RuntimeError("CEC support is not available (python-cec not installed).")
         self._mqtt_send = mqtt_send
         self.devices = devices
         self.volume_correction = 1  # 80/100 = max volume of avr / reported max volume

--- a/src/cec_mqtt_bridge/lirc_if.py
+++ b/src/cec_mqtt_bridge/lirc_if.py
@@ -3,7 +3,10 @@
 """lirc interface to HDMI CEC MQTT bridge"""
 import logging
 import threading
-import lirc
+try:
+    import lirc
+except ModuleNotFoundError:
+    lirc = None
 
 LOGGER = logging.getLogger(__name__)
 
@@ -18,6 +21,8 @@ class Lirc:
     """lirc IR interface class"""
 
     def __init__(self, mqtt_send, config: dict):
+        if lirc is None:
+            raise RuntimeError("IR support is not available (python-lirc not installed).")
         self._config = config
         self._mqtt_send = mqtt_send
         self.stop_event = threading.Event()


### PR DESCRIPTION
* The README was corrected and clarified (installation path, optional LIRC).
* Optional dependencies such as **CEC** and **LIRC** are clearly documented and only required when the corresponding features are enabled.
* No import errors occur when optional features are disabled; if they are enabled but dependencies are missing, a clear error message is shown.
* The default configuration is now consistent with the code and the documentation.